### PR TITLE
Time zone request

### DIFF
--- a/src/components/Weather/HourlyWeather/HourlyWeather.js
+++ b/src/components/Weather/HourlyWeather/HourlyWeather.js
@@ -8,7 +8,11 @@ const HourlyWeather = ( props ) => {
 	let hours = props.hourlyWeather.list.map( (hour, index) => {
 		// Include only the next 24 hours
 		if (index < 8) {
-			const time = new Date(hour.dt * 1000).toLocaleString(undefined, { hour: '2-digit' }).toLowerCase();
+			const time = new Date(hour.dt * 1000).toLocaleString('en-US', { 
+				timeZone: props.timeZone,
+				hour: '2-digit'
+			}).toLowerCase();
+
 			let iconClasses = '';
 
 			for (let i = 0; i < weatherConditions.length; i++) {
@@ -30,7 +34,8 @@ const HourlyWeather = ( props ) => {
 				</tr>
 			)
 		}
-	})
+	});
+	
 	return (
 		<div className="hourly-container">
 			<table className="hourly-table">

--- a/src/components/Weather/SunriseSunset/SunriseSunset.js
+++ b/src/components/Weather/SunriseSunset/SunriseSunset.js
@@ -12,8 +12,20 @@ const SunriseSunset = ( props ) => {
 						<td><i className="wi wi-sunset"></i></td>
 					</tr>
 					<tr>
-						<td>{new Date(props.sunrise * 1000).toLocaleString(undefined, { hour: '2-digit', minute: '2-digit'})}</td>
-						<td>{new Date(props.sunset * 1000).toLocaleString(undefined, { hour: '2-digit', minute: '2-digit'})}</td>
+						<td>{
+							new Date(props.sunrise * 1000).toLocaleString('en-us', {
+								timeZone: props.timeZone,
+								hour: '2-digit', 
+								minute: '2-digit'
+							})
+						}</td>
+						<td>{
+							new Date(props.sunset * 1000).toLocaleString('en-us', {
+								timeZone: props.timeZone, 
+								hour: '2-digit', 
+								minute: '2-digit'
+							})
+						}</td>
 					</tr>
 				</tbody>
 			</table>

--- a/src/components/Weather/Weather.js
+++ b/src/components/Weather/Weather.js
@@ -31,11 +31,13 @@ const Weather = ( props ) => {
 				isLightOut={props.isLightOut} />
 			<SunriseSunset 
 				sunrise={props.sunrise}
-				sunset={props.sunset} />
+				sunset={props.sunset}
+				timeZone={props.timeZone} />
 			<HourlyWeather 
 				hourlyWeather={props.hourlyWeather}
 				weatherConditions={props.weatherConditions}
-				isLightOut={props.isLightOut} />
+				isLightOut={props.isLightOut}
+				timeZone={props.timeZone} />
 		</div>
 	)
 }


### PR DESCRIPTION
The OpenWeatherAPI returns timestamps in unix UTC format, but there is no timezone information in the response.  To show the correct sunrise and sunset times in the **local** time of the city the user is searching for an additional API request was needed.

The TimeZoneDB api takes lat/long. coordinates and returns a json object with a timezone string.  The timezone string is then set to state and passed to child components to convert the unix times to the appropriate time of the city the user is searching for